### PR TITLE
fix: prevent recursion in _get_radar_catalog (closes #31)

### DIFF
--- a/src/adapt/api/client.py
+++ b/src/adapt/api/client.py
@@ -110,11 +110,18 @@ class DataClient:
 
     def _get_radar_catalog(self, radar: str) -> RadarCatalog:
         """Get radar catalog instance."""
-        if radar not in self._radar_catalogs:
+        if radar in self._radar_catalogs:
+            return self._radar_catalogs[radar]
+        # Prevent re-entrance during initialization
+        self._radar_catalogs[radar] = None  # placeholder
+        try:
             radar_dir = self.root_dir / radar
             if not radar_dir.exists():
                 raise FileNotFoundError(f"Radar directory not found: {radar_dir}")
             self._radar_catalogs[radar] = RadarCatalog(radar_dir)
+        except Exception:
+            del self._radar_catalogs[radar]  # cleanup on failure
+            raise
         return self._radar_catalogs[radar]
 
     # =========================================================================


### PR DESCRIPTION
## What
The `_get_radar_catalog` method could trigger recursive calls if `RadarCatalog` initialization (or logging/error handling within it) calls back into DataClient, leading to infinite recursion and a RecursionError. The traceback shows the recursion ultimately happens in matplotlib's drawing code.

## Fix
Added a re-entrance guard by pre-inserting a placeholder (`None`) into the `_radar_catalogs` cache before constructing the `RadarCatalog`. If the construction fails, the placeholder is removed. This ensures that even if `RadarCatalog.__init__` triggers a callback that calls `_get_radar_catalog` again for the same radar, it will immediately return the placeholder (which then becomes the real catalog upon first success).

Closes #31